### PR TITLE
Comment H4 a tag remove underline

### DIFF
--- a/themes/slashcode/htdocs/comments.cssraw
+++ b/themes/slashcode/htdocs/comments.cssraw
@@ -76,6 +76,7 @@ html > body .commentwrap table {
 
 .commentTop a{
     color: #fff;
+    text-decoration: none;
 }
 
 
@@ -86,6 +87,7 @@ html > body .commentwrap table {
 	padding: .3em .6em;
 	background:#aaa;
 }
+
 
 .commentTop .details {
 	font-size: .75em;


### PR DESCRIPTION
Since this is an anchor and not a link, set text decoration to none.
