### PR TITLE
Change Makefile to respect INSTALL_BASE from ExtUtils::MakeMaker

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -445,6 +445,9 @@ INSTALLATION
                                                         installed files
                 INIT            /etc or /etc/rc.d       Location for init
                                                         scripts
+                INSTALL_BASE    (none)                  Change location
+                                                        where modules are
+                                                        installed
                 USER            nobody                  User to own files
                 GROUP           nobody                  Group to own files
                 CP              cp                      Name of or path to

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,13 @@ INSTALLMAN3DIR=`$(PERL) -MConfig -e 'print "$(BUILDROOT)/$$Config{installman3dir
 slash:
 	@echo "=== INSTALLING SLASH MODULES ==="
 	@if [ ! "$(RPM)" ] ; then \
-		(cd Slash; $(PERL) Makefile.PL; $(MAKE) install UNINST=1); \
+		(cd Slash; \
+		if [ ! "$(INSTALL_BASE)" ]; then \
+			$(PERL) Makefile.PL; \
+		else \
+			$(PERL) Makefile.PL INSTALL_BASE=$(INSTALL_BASE); \
+		fi; \
+		$(MAKE) install UNINST=1); \
 	else \
 		echo " - Performing an RPM build"; \
 		(cd Slash; $(PERL) Makefile.PL INSTALLSITEARCH=$(INSTALLSITEARCH) INSTALLSITELIB=$(INSTALLSITELIB) INSTALLMAN3DIR=$(INSTALLMAN3DIR); $(MAKE) install UNINST=1); \
@@ -87,7 +93,11 @@ pluginsandtagboxes:
 		 echo == $$PWD; \
 		 if [ -f Makefile.PL ]; then \
 		 	if [ ! "$(RPM)" ] ; then \
-				$(PERL) Makefile.PL; \
+				if [ ! "$(INSTALL_BASE)" ]; then \
+					$(PERL) Makefile.PL; \
+				else \
+					$(PERL) Makefile.PL INSTALL_BASE=$(INSTALL_BASE); \
+				fi; \
 				$(MAKE) install UNINST=1;\
 				$(MAKE) realclean; \
 			else \


### PR DESCRIPTION
Passes INSTALL_BASE to perl Makefile.pl as expected by ExtUtils::MakeMaker.

This allows for building slashcode as a non-privileged user
