### PR TITLE
Fix Issue 63 by added link to title txt on articles

### DIFF
--- a/themes/slashcode/htdocs/base.css
+++ b/themes/slashcode/htdocs/base.css
@@ -423,6 +423,11 @@ html .generaltitle,* html .generalbody,* html .article .body,* html .article .de
 	color: #fff;
 }
 
+.generaltitle h3 a
+{
+	text-decoration: none;
+}
+
 .generaltitle h3 a, .generaltitle h3 a:visited
 {
 	color: #fff;

--- a/themes/slashcode/templates/dispStory;misc;default
+++ b/themes/slashcode/templates/dispStory;misc;default
@@ -43,7 +43,7 @@ __template__
 	END;
 	title = title _ thisskin.title _ "</a>: $story.title";
 ELSE;
-	title = story.title;
+	title = "<a href=\"$gSkin.rootdir/article.pl?sid=$story.sid\">story.title</a>";
 END %]
 [% seen_topics = {} %]
 [% PROCESS titlebar future=story.is_future %]


### PR DESCRIPTION
Added a tag with correct sort link to title of the story.

Styled general title h3 a to have no underline.
