### PR TITLE
Fix for nested commentBody in generalbody for Issue #128

### DIFF
--- a/themes/slashcode/htdocs/comments.cssraw
+++ b/themes/slashcode/htdocs/comments.cssraw
@@ -128,6 +128,11 @@ html > body .commentwrap table {
 	font-size: .875em;
 }
 
+.generalbody .commentBody {
+    padding: 1em .8em .4em .8em;
+    font-size: 1em;
+}
+
 .commentBody p, #editComment p, #editComment label
 {
     margin-top:0;


### PR DESCRIPTION
when commentBody is nested in generalbody in a comment preview, the
font size reduction is set twice.  New css sets the specific situation
to 1em instead of .875em.  Also adds a bit of padding that is needed
because of the missing buttons.
