### PR TITLE
Fix a typo in a url in about.shtml

### DIFF
--- a/themes/slashcode/htdocs/about.shtml
+++ b/themes/slashcode/htdocs/about.shtml
@@ -22,7 +22,7 @@
 <li><a href="http://wiki.soylentnews.org/wiki/SoylentNews" target="blank">Wiki</a></li>
 <li><a href="http://wiki.soylentnews.org/wiki/SoylentNews:IRC" target="blank">IRC - Wiki Page</a></li>
 <li><a href="http://chat.soylentnews.org" target="blank">IRC Web Chat</a></li>
-<li><a href="http://wiki.soylentnews.org/wiki/WhosWho' target="blank">Who's Who?</a></li>
+<li><a href="http://wiki.soylentnews.org/wiki/WhosWho" target="blank">Who's Who?</a></li>
 <li><a href="https://github.com/SoylentNews/slashcode/issues" target="blank">Bug List</a></li>
 <li><a href="https://github.com/SoylentNews" target="blank">The slashcode repository for SoylentNews on GitHub</a></li>
 </ul>


### PR DESCRIPTION
Used a ‘ instead of “ in the WhosWho url.

Did a manual fix on production directly on the file to fix.  This is to get the fix into the repo for future deploys.
