### PR TITLE
fix encoding of html in rss description

### DIFF
--- a/Slash/XML/RSS/RSS.pm
+++ b/Slash/XML/RSS/RSS.pm
@@ -445,7 +445,7 @@ sub rss_story {
 				if $action;
 			# add poll if any
 			$extra .= pollbooth($story->{qid},1, 0, 1) if $story->{qid};
-			$encoded_item->{description} .= $self->encode($extra) if $extra;
+
 			#Encdoe with CDATA instead
 			#$encoded_item->{description} .= $self->encode($extra) if $extra;
 			$encoded_item->{description} .= $extra if $extra;


### PR DESCRIPTION
use CDATA block instead of encoding the html using entities.
