### PR TITLE
Removed a partial errant html anchor 'tag' that borks the homepage.

### DIFF
--- a/themes/default/templates/headMessage;misc;default
+++ b/themes/default/templates/headMessage;misc;default
@@ -14,7 +14,7 @@ __template__
 [% subs = Slash.db.getSubmissionCount() %]
 
 [% IF subs < constants.subs_level %]
-<div id="head_message">[% constants.sitename %] is powered by your submissions, so <a href="[% gSkin.rootdir %]/submit.pl">send in your scoop</a>. Only <b>[% subs %]</b> <a href="submission[% IF subs != 1  %]s[% END %] in the queue.</div>
+<div id="head_message">[% constants.sitename %] is powered by your submissions, so <a href="[% gSkin.rootdir %]/submit.pl">send in your scoop</a>. Only <b>[% subs %]</b> submission[% IF subs != 1  %]s[% END %] in the queue.</div>
 
 [% ELSE %]
 


### PR DESCRIPTION
Removed floating '<a href="' from the 'submission(s) in the queue' code.  Copy and paste bug?  It was borking the html and the main page had overlapping boxes.

Note: the open <a href="..... tag gobbled up all the following HTML code until the next </a> closing tag.  This ate up all the code until the About link in the Navigation box seriously borking the html and page layout.
