### PR TITLE
Closed open Anchor elements

### DIFF
--- a/themes/default/templates/listAbuses;users;default
+++ b/themes/default/templates/listAbuses;users;default
@@ -26,9 +26,9 @@ __template__
 [% FOR abuse = abuses %]
 	<tr>
 		<td>[% abuse.0 %]</td>
-		<td><a href="[% gSkin.rootdir %]/users.pl?op=userinfo&amp;userfield=[% abuse.1 %]">[% abuse.1 %]</td>
-		<td><a href="[% gSkin.rootdir %]/users.pl?op=userinfo&amp;userfield=[% abuse.2 %]">[% abuse.2 %]</td>
-		<td><a href="[% gSkin.rootdir %]/users.pl?op=userinfo&amp;userfield=[% abuse.3 %]">[% abuse.3 %]</td>
+		<td><a href="[% gSkin.rootdir %]/users.pl?op=userinfo&amp;userfield=[% abuse.1 %]">[% abuse.1 %]</a></td>
+		<td><a href="[% gSkin.rootdir %]/users.pl?op=userinfo&amp;userfield=[% abuse.2 %]">[% abuse.2 %]</a></td>
+		<td><a href="[% gSkin.rootdir %]/users.pl?op=userinfo&amp;userfield=[% abuse.3 %]">[% abuse.3 %]</a></td>
 		<td>[% abuse.4 %]</td>
 	</tr>
 [% END %]


### PR DESCRIPTION
Added a close tag for the anchors in the report table.  I found this when I found the misplaced partial anchor tag in 'headMessage;misc;default' in pull request 184.

Unlike 184, this wasn't creating a problem b/c browsers automatically closed the anchor when it saw the TD close.  This is just cleaner and won't cause issues if the HTML is changed.

'topAbusers;users;default' already contains the close tag. So this also makes things consistent.
