### PR TITLE
Working-ish unicode

### DIFF
--- a/Slash/Apache/Apache.pm
+++ b/Slash/Apache/Apache.pm
@@ -5,6 +5,7 @@
 package Slash::Apache;
 
 use strict;
+use utf8;
 use Time::HiRes;
 use Apache;
 use Apache::SIG ();

--- a/Slash/Apache/Banlist/Banlist.pm
+++ b/Slash/Apache/Banlist/Banlist.pm
@@ -7,6 +7,7 @@
 package Slash::Apache::Banlist;
 
 use strict;
+use utf8;
 use Apache::Constants qw(:common);
 
 use Slash;

--- a/Slash/Apache/Log/Log.pm
+++ b/Slash/Apache/Log/Log.pm
@@ -5,6 +5,7 @@
 package Slash::Apache::Log;
 
 use strict;
+use utf8;
 use Slash::Utility;
 use Apache::Constants qw(:common);
 

--- a/Slash/Apache/User/User.pm
+++ b/Slash/Apache/User/User.pm
@@ -5,6 +5,7 @@
 package Slash::Apache::User;
 
 use strict;
+use utf8;
 use Digest::MD5 'md5_hex';
 use Time::HiRes;
 use Apache;

--- a/plugins/Admin/admin.pl
+++ b/plugins/Admin/admin.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Image::Size;
 use Time::HiRes;
 use LWP::UserAgent;

--- a/plugins/Admin/refresh_uncommon.pl
+++ b/plugins/Admin/refresh_uncommon.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/plugins/Admin/topic_popup_static.pl
+++ b/plugins/Admin/topic_popup_static.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 use Slash::Admin::PopupTree;

--- a/plugins/Admin/topic_tree_draw.pl
+++ b/plugins/Admin/topic_tree_draw.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/plugins/Ajax/htdocs/ajax.pl
+++ b/plugins/Ajax/htdocs/ajax.pl
@@ -4,6 +4,7 @@
 # and COPYING for more information, or see http://slashcode.com/.
 
 use strict;
+use utf8;
 use warnings;
 
 use Data::JavaScript::Anon;

--- a/plugins/Ajax/htdocs/preferences.pl
+++ b/plugins/Ajax/htdocs/preferences.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash;
 use Slash::Display;

--- a/plugins/Blob/blob.pl
+++ b/plugins/Blob/blob.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Blob;
 use Slash::Utility;

--- a/plugins/Blob/clean_blobs.pl
+++ b/plugins/Blob/clean_blobs.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash::Constants ':slashd';
 use Slash::Display;
 

--- a/plugins/Blob/fileadmin.pl
+++ b/plugins/Blob/fileadmin.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash 2.003;
 use Slash::Blob;
 use Slash::Display;

--- a/plugins/DynamicBlocks/createboxes.pl
+++ b/plugins/DynamicBlocks/createboxes.pl
@@ -4,6 +4,7 @@
 # and COPYING for more information, or see http://slashcode.com/.
 
 use strict;
+use utf8;
 use File::Basename;
 use Getopt::Std;
 use Slash;

--- a/plugins/DynamicBlocks/dynamic_blocks_admin_update.pl
+++ b/plugins/DynamicBlocks/dynamic_blocks_admin_update.pl
@@ -5,6 +5,7 @@
 # and COPYING for more information, or see http://slashcode.com/.
 
 use strict;
+use utf8;
 
 use Slash;
 use Slash::Constants ':slashd';

--- a/plugins/Edit/delete_stale_previews.pl
+++ b/plugins/Edit/delete_stale_previews.pl
@@ -4,6 +4,7 @@
 # and COPYING for more information, or see http://slashcode.com/.
 
 use strict;
+use utf8;
 
 use Slash;
 use Slash::Constants ':slashd';

--- a/plugins/Edit/edit.pl
+++ b/plugins/Edit/edit.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use File::Temp 'tempfile';
 use Image::Size;
 use Time::HiRes;

--- a/plugins/Email/email.pl
+++ b/plugins/Email/email.pl
@@ -10,6 +10,7 @@
 # (c) OSTG 2002
 
 use strict;
+use utf8;
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/Events/calendar.pl
+++ b/plugins/Events/calendar.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/Events/events.pl
+++ b/plugins/Events/events.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/Events/eventsadmin.pl
+++ b/plugins/Events/eventsadmin.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Events;

--- a/plugins/Events/vcal.pl
+++ b/plugins/Events/vcal.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/FAQ/faq.pl
+++ b/plugins/FAQ/faq.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/Hof/hof.pl
+++ b/plugins/Hof/hof.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/HumanConf/hc_maintain_pool.pl
+++ b/plugins/HumanConf/hc_maintain_pool.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash::Utility;
 
 use vars qw( %task $me $task_exit_flag );

--- a/plugins/Journal/journal.pl
+++ b/plugins/Journal/journal.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Constants qw(:messages :web);
 use Slash::Display;

--- a/plugins/Journal/journal_fix.pl
+++ b/plugins/Journal/journal_fix.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use File::Spec::Functions;
 use Slash::Constants ':slashd';
 use Slash::Utility;

--- a/plugins/Login/login.pl
+++ b/plugins/Login/login.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash 2.003;
 use Slash::Constants qw(:web :messages);
 use Slash::Display;

--- a/plugins/Messages/message_delete.pl
+++ b/plugins/Messages/message_delete.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use File::Spec::Functions;
 use Slash::Utility;
 

--- a/plugins/Messages/message_delivery.pl
+++ b/plugins/Messages/message_delivery.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use File::Spec::Functions;
 use Slash::Utility;
 use Slash::Constants qw(:slashd :messages);

--- a/plugins/Messages/messages.pl
+++ b/plugins/Messages/messages.pl
@@ -8,6 +8,7 @@
 # so i document it here.  yay for me!
 
 use strict;
+use utf8;
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Constants qw(:web :messages);
 use Slash::Display;

--- a/plugins/Messages/setprefs.pl
+++ b/plugins/Messages/setprefs.pl
@@ -4,6 +4,7 @@
 # and COPYING for more information, or see http://slashcode.com/.
 
 use strict;
+use utf8;
 use File::Basename;
 use Getopt::Std;
 use Slash;

--- a/plugins/Messages/test.pl
+++ b/plugins/Messages/test.pl
@@ -24,6 +24,7 @@ exit;
 # of the test code):
 
 use strict;
+use utf8;
 use Slash 2.001;
 use Slash::Utility;
 $ARGV[0] ||= 'virtual_user=slash';

--- a/plugins/Metamod/metamod.pl
+++ b/plugins/Metamod/metamod.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/Metamod/process_metamod.pl
+++ b/plugins/Metamod/process_metamod.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash::Utility;
 use Slash::Constants qw( :messages :slashd );
 

--- a/plugins/Moderation/moderate.pl
+++ b/plugins/Moderation/moderate.pl
@@ -10,6 +10,7 @@
 # moderate.pl.
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Constants qw(:messages :strip);
 use Slash::Display;

--- a/plugins/Moderation/process_moderation.pl
+++ b/plugins/Moderation/process_moderation.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Utility;
 use Slash::Constants qw( :messages :slashd );

--- a/plugins/PollBooth/pollBooth.pl
+++ b/plugins/PollBooth/pollBooth.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/plugins/Print/print.pl
+++ b/plugins/Print/print.pl
@@ -33,6 +33,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use HTML::TreeBuilder;
 use Slash;
 use Slash::Display;

--- a/plugins/Remarks/remarks.pl
+++ b/plugins/Remarks/remarks.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use warnings;
 
 use Slash 2.003;	# require Slash 2.3.x

--- a/plugins/ResKey/tasks/reskey_purge.pl
+++ b/plugins/ResKey/tasks/reskey_purge.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants qw(:slashd :reskey);
 

--- a/plugins/SOAP/example_client.pl
+++ b/plugins/SOAP/example_client.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Data::Dumper;
 use SOAP::Lite;
 

--- a/plugins/SOAP/soap.pl
+++ b/plugins/SOAP/soap.pl
@@ -9,6 +9,7 @@
 # and the Users code is just there temporarily for testing.
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Utility;
 

--- a/plugins/Search/SOAP/search_client.pl
+++ b/plugins/Search/SOAP/search_client.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Data::Dumper;
 use SOAP::Lite;
 

--- a/plugins/Search/search.pl
+++ b/plugins/Search/search.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Search;
 use Slash::Display;

--- a/plugins/Stats/adminmail.pl
+++ b/plugins/Stats/adminmail.pl
@@ -4,6 +4,7 @@
 # and COPYING for more information, or see http://slashcode.com/.
 
 use strict;
+use utf8;
 use Slash::Constants qw( :messages :slashd );
 use Slash::Display;
 

--- a/plugins/Stats/stats.pl
+++ b/plugins/Stats/stats.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use File::Path;
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Constants qw(:web);

--- a/plugins/Stats/stats_graphs_delete.pl
+++ b/plugins/Stats/stats_graphs_delete.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash::Utility;
 
 my $me = 'stats_graphs_delete.pl';

--- a/plugins/Submit/submit.pl
+++ b/plugins/Submit/submit.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Constants qw(:messages :web);
 use Slash::Display;

--- a/plugins/Subscribe/subscribe.pl
+++ b/plugins/Subscribe/subscribe.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash;
 use Slash::Display;

--- a/plugins/Subscribe/subscribemail.pl
+++ b/plugins/Subscribe/subscribemail.pl
@@ -4,6 +4,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash::Constants qw(:messages);
 
 use vars qw( %task $me );

--- a/plugins/Unsubscribe/unsubscribe.pl
+++ b/plugins/Unsubscribe/unsubscribe.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use File::Path;
 use Slash 2.003;        # require Slash 2.3.x
 use Slash::Constants qw(:messages :web);

--- a/plugins/Zoo/zoo.pl
+++ b/plugins/Zoo/zoo.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Constants qw(:web :people :messages);
 use Slash::Display;

--- a/plugins/Zoo/zoo_run_people_log.pl
+++ b/plugins/Zoo/zoo_run_people_log.pl
@@ -3,6 +3,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash::Constants qw( :messages :slashd :people );
 use Slash::Display;
 

--- a/themes/default/htdocs/404.pl
+++ b/themes/default/htdocs/404.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use File::Spec::Functions;
 use Slash;
 use Slash::Display;

--- a/themes/default/htdocs/about.pl
+++ b/themes/default/htdocs/about.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/themes/default/htdocs/article.pl
+++ b/themes/default/htdocs/article.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/themes/default/htdocs/authors.pl
+++ b/themes/default/htdocs/authors.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/themes/default/htdocs/badge.pl
+++ b/themes/default/htdocs/badge.pl
@@ -2,6 +2,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/themes/default/htdocs/comments.pl
+++ b/themes/default/htdocs/comments.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Constants qw(:messages :strip);
 use Slash::Display;

--- a/themes/default/htdocs/imgupload.pl
+++ b/themes/default/htdocs/imgupload.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash;
 use Slash::Display;

--- a/themes/default/htdocs/index.pl
+++ b/themes/default/htdocs/index.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/themes/default/htdocs/shtml.pl
+++ b/themes/default/htdocs/shtml.pl
@@ -4,6 +4,7 @@
 # and COPYING for more information, or see http://slashcode.com/.
 
 use strict;
+use utf8;
 
 use File::Spec::Functions;
 use Slash;

--- a/themes/default/htdocs/topics.pl
+++ b/themes/default/htdocs/topics.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Display;
 use Slash::Utility;

--- a/themes/default/htdocs/users.pl
+++ b/themes/default/htdocs/users.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Digest::MD5 'md5_hex';
 use Slash;
 use Slash::Display;

--- a/themes/default/tasks/accesslog_artcom.pl
+++ b/themes/default/tasks/accesslog_artcom.pl
@@ -6,6 +6,7 @@
 # table, accesslog_artcom, for fast processing by run_moderatord.
 
 use strict;
+use utf8;
 use vars qw( %task $me $minutes_run );
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::DB;

--- a/themes/default/tasks/balance_readers.pl
+++ b/themes/default/tasks/balance_readers.pl
@@ -8,6 +8,7 @@
 # later. - Jamie 2004/11/10
 
 use strict;
+use utf8;
 
 use Time::HiRes;
 

--- a/themes/default/tasks/counthits.pl
+++ b/themes/default/tasks/counthits.pl
@@ -7,6 +7,7 @@
 # Counts hits from accesslog and updates stories.hits columns.
 
 use strict;
+use utf8;
 use vars qw( %task $me $minutes_run $maxrows %timehash );
 use Time::HiRes;
 use Slash::DB;

--- a/themes/default/tasks/daily.pl
+++ b/themes/default/tasks/daily.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants qw(:slashd :messages);
 use Slash::Display;

--- a/themes/default/tasks/daily_archive.pl
+++ b/themes/default/tasks/daily_archive.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Fcntl;
 use Slash::Constants ':slashd';

--- a/themes/default/tasks/daily_forget.pl
+++ b/themes/default/tasks/daily_forget.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/dbsparklines.pl
+++ b/themes/default/tasks/dbsparklines.pl
@@ -7,6 +7,7 @@
 use Slash::Constants ':slashd';
 
 use strict;
+use utf8;
 use Time::HiRes;
 
 use vars qw( %task $me );

--- a/themes/default/tasks/delete_accesslog.pl
+++ b/themes/default/tasks/delete_accesslog.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Fcntl;
 use Slash::Constants ':slashd';

--- a/themes/default/tasks/expire.pl
+++ b/themes/default/tasks/expire.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use vars qw( %task $me );
 use Slash;
 use Slash::DB;

--- a/themes/default/tasks/flush_formkeys.pl
+++ b/themes/default/tasks/flush_formkeys.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/freshenup.pl
+++ b/themes/default/tasks/freshenup.pl
@@ -11,6 +11,7 @@ use Digest::MD5;
 use Slash::Constants ':slashd';
 
 use strict;
+use utf8;
 
 use vars qw( %task $me $task_exit_flag
 	$minutes_run

--- a/themes/default/tasks/html_update.pl
+++ b/themes/default/tasks/html_update.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Time::HiRes;
 use Slash::Constants ':slashd';

--- a/themes/default/tasks/log_db_qps.pl
+++ b/themes/default/tasks/log_db_qps.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use vars qw( %task $me );
 use Slash;
 use Slash::DB;

--- a/themes/default/tasks/new_headfoot.pl
+++ b/themes/default/tasks/new_headfoot.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use File::Path;
 use Slash::Constants ':slashd';

--- a/themes/default/tasks/new_motd.pl
+++ b/themes/default/tasks/new_motd.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/open_backend.pl
+++ b/themes/default/tasks/open_backend.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use Slash;
 use Slash::XML;
 use Slash::Constants ':slashd';

--- a/themes/default/tasks/p2f_hof_topics.pl
+++ b/themes/default/tasks/p2f_hof_topics.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/performance_stats.pl
+++ b/themes/default/tasks/performance_stats.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/precache_gse.pl
+++ b/themes/default/tasks/precache_gse.pl
@@ -10,6 +10,7 @@
 # jellicle for suggesting this!  :)
 
 use strict;
+use utf8;
 use vars qw( %task $me );
 use Time::HiRes;
 use Slash::DB;

--- a/themes/default/tasks/process_file_queue.pl
+++ b/themes/default/tasks/process_file_queue.pl
@@ -11,6 +11,7 @@ use Image::Size;
 use Slash::Constants ':slashd';
 
 use strict;
+use utf8;
 
 use vars qw( %task $me $task_exit_flag );
 

--- a/themes/default/tasks/refresh_authors_cache.pl
+++ b/themes/default/tasks/refresh_authors_cache.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/refresh_section_metakeywords.pl
+++ b/themes/default/tasks/refresh_section_metakeywords.pl
@@ -8,6 +8,7 @@
 # in HTML output.
 
 use strict;
+use utf8;
 
 use Slash::Display;
 

--- a/themes/default/tasks/report_slashd_errors.pl
+++ b/themes/default/tasks/report_slashd_errors.pl
@@ -5,6 +5,7 @@
 ## $Id$
 
 use strict;
+use utf8;
 use Slash::Constants qw( :messages :slashd );
 
 use vars qw( %task $me );

--- a/themes/default/tasks/rotate_semirandom_block.pl
+++ b/themes/default/tasks/rotate_semirandom_block.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/rss_submit.pl
+++ b/themes/default/tasks/rss_submit.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use File::Path;
 use Slash::Constants ':slashd';

--- a/themes/default/tasks/run_moderatord.pl
+++ b/themes/default/tasks/run_moderatord.pl
@@ -6,6 +6,7 @@
 # located in plugins/(your moderation plugin here).
 
 use strict;
+use utf8;
 
 use Slash 2.003;	# require Slash 2.3.x
 use Slash::Constants qw(:messages);

--- a/themes/default/tasks/run_portald.pl
+++ b/themes/default/tasks/run_portald.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 
 use Slash::Constants ':slashd';
 

--- a/themes/default/tasks/set_cids.pl
+++ b/themes/default/tasks/set_cids.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use vars qw( %task $me );
 use Slash;
 use Slash::DB;

--- a/themes/default/tasks/set_gse_min_stoid.pl
+++ b/themes/default/tasks/set_gse_min_stoid.pl
@@ -8,6 +8,7 @@
 # minimum stoid returned, and writes it to a var.
 
 use strict;
+use utf8;
 use vars qw( %task $me );
 use Time::HiRes;
 use Slash::DB;

--- a/themes/default/tasks/set_recent_topics.pl
+++ b/themes/default/tasks/set_recent_topics.pl
@@ -9,6 +9,7 @@
 # <shane at lottadot dot com>, May 2002.
 
 use strict;
+use utf8;
 use Slash::Constants ':slashd';
 
 use vars qw( %task $me );

--- a/themes/default/tasks/spamarmor.pl
+++ b/themes/default/tasks/spamarmor.pl
@@ -5,6 +5,7 @@
 # $Id$
 
 use strict;
+use utf8;
 use vars qw( %task $me );
 use Slash;
 use Slash::DB;

--- a/themes/default/tasks/url_checker.pl
+++ b/themes/default/tasks/url_checker.pl
@@ -13,6 +13,7 @@ use HTTP::Request;
 use Encode 'encode_utf8';
 
 use strict;
+use utf8;
 
 use vars qw( %task $me $task_exit_flag );
 


### PR DESCRIPTION
This pull gives us working-ish unicode. By working-ish I mean every script should be able to handle wide characters and for some reason they get html-encoded. I don't believe that was me, likely someone else's work in an earlier commit that wasn't working without use utf8.

Not sure if all of these are absolutely necessary but I'm going with "handle utf-8 right unless you've a reason not to" as my working theory. Consequently this includes ALL .pl files and all the .pm files loaded by the vhost conf file.

This will almost certainly break "something" but I'm way too small a dataset to find all the issues.
