### PR TITLE
Allow for possibility of index.pl feeds for anonymous users.

### DIFF
--- a/sql/mysql/defaults.sql
+++ b/sql/mysql/defaults.sql
@@ -1060,7 +1060,7 @@ INSERT INTO vars (name, value, description) VALUES ('recent_topic_txt_count','5'
 INSERT INTO vars (name, value, description) VALUES ('referrer_external_static_redirect','1','If true, redirect anon requests referred from other sites for dynamic article.pl to static .shtml. This can greatly improve chances of surviving a slashdotting');
 INSERT INTO vars (name, value, description) VALUES ('returnto_passwd',CONCAT('changeme',RAND()),'Password used to sign MD5s for returnto URLs from remote sites');
 INSERT INTO vars (name, value, description) VALUES ('rootdir','//www.example.com','Base URL of site; used for creating on-site links that need protocol-inspecific URL (so site can be used via HTTP and HTTPS at the same time)');
-INSERT INTO vars (name, value, description) VALUES ('rss_allow_index', '0', 'Allow RSS feeds to be served from index.pl (1 = admins, 2 = subscribers, 3 = all logged-in users)');
+INSERT INTO vars (name, value, description) VALUES ('rss_allow_index', '0', 'Allow RSS feeds to be served from index.pl (1 = admins, 2 = subscribers, 3 = all logged-in users, 4 = anonymous connections)');
 INSERT INTO vars (name, value, description) VALUES ('rss_expire_days','7','Number of days till we blank the data from the database (the signatures still stick around though)');
 INSERT INTO vars (name, value, description) VALUES ('rss_max_items_incoming','15','Max number of rss items shown in a slashbox, by default');
 INSERT INTO vars (name, value, description) VALUES ('rss_max_items_outgoing','10','Max number of rss items emitted in an rss/rdf/atom feed');

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -290,3 +290,6 @@ ALTER TABLE xsite_auth_log CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci
 # Add quote to the approved tags list for comments
 UPDATE vars SET value = 'b|i|p|br|a|ol|ul|li|dl|dt|dd|em|strong|tt|blockquote|div|ecode|quote' WHERE name = 'approvedtags';
 UPDATE vars SET value = 'p|br|ol|ul|li|dl|dt|dd|blockquote|div|img|hr|h1|h2|h3|h4|h5|h6|quote' WHERE name = 'approvedtags_break';
+
+# Add the ability to serve up anonymous dynamic rss/atom feeds from index.pl rather than only for certain classes of logged in users
+UPDATE vars SET description = 'Allow RSS feeds to be served from index.pl (1 = admins, 2 = subscribers, 3 = all logged-in users, 4 = anonymous connections)' WHERE name = 'rss_allow_index';

--- a/themes/default/htdocs/index.pl
+++ b/themes/default/htdocs/index.pl
@@ -43,6 +43,7 @@ my $start_time = Time::HiRes::time;
 			   $user->{is_admin}
 			|| ($constants->{rss_allow_index} > 1 && $user->{is_subscriber})
 			|| ($constants->{rss_allow_index} > 2 && !$user->{is_anon})
+			|| ($constants->{rss_allow_index} > 3 )
 		);
 
 	# $form->{logtoken} is only allowed if using rss

--- a/themes/default/templates/rsslink;misc;default
+++ b/themes/default/templates/rsslink;misc;default
@@ -19,6 +19,8 @@ __template__
 	(constants.rss_allow_index > 1 && user.is_subscriber)
 		||
 	(constants.rss_allow_index > 2 && !user.is_anon)
+		||
+	(constants.rss_allow_index > 3)
 ));
 %][% Slash.root2abs() %]/index.pl?content_type=[% feed_type %]&amp;logtoken=[% Slash.getPublicLogToken() | strip_paramattr %][%
     ELSE


### PR DESCRIPTION
Currently index.pl can serve up dynamic rss/rdf/atom only to the admin's choice of admin, subscribers, or logged in users, this allows the site admin the choice of allowing anonymous users as well should they want to serve up dynamic feeds in addition to or in place of the static ones generated periodically by slashd.

I'm not saying we should necessarily do it but having the option would not be a bad thing.
