### PR TITLE
Fix for the race condition paulej72 described in #136.

### DIFF
--- a/themes/default/htdocs/users.pl
+++ b/themes/default/htdocs/users.pl
@@ -2949,8 +2949,12 @@ sub saveHome {
 	# (There's no way to have an "always" author, at the moment.)
 	for my $aid (sort { $a <=> $b } keys %$author_hr) {
 		my $key = "aid$aid";
+		##########
+		# TMB only add author to story_never_author if they are in the hidden list
+		# and are not in the list of checked authors.
+		my $check = "hid$aid";
 		$story_author_all++;
-		if (!$form->{$key}) {			push @story_never_author, $aid	}
+		if ( (!$form->{$key}) && ($form->{$check}) ) {push @story_never_author, $aid;}
 	}
 	# Nexuses can have value 0, 1, 2, 3, 4, 5.  
 	# 0 means the never list,

--- a/themes/default/templates/tildeEd;users;default
+++ b/themes/default/templates/tildeEd;users;default
@@ -157,7 +157,9 @@ __template__
 	<tr>
 		<td><input type="checkbox" name="aid[% aid %]"
 			[%- checked IF story023_default.author.$aid > 0 %]>
-			[% authorref.$aid | strip_literal %]</td>
+			[% authorref.$aid | strip_literal %]
+			<input type="hidden" name="hid[% aid %]" value="1">
+		</td>
 	</tr>
 [% END %]
 </table>


### PR DESCRIPTION
As simple as I could make it. If hid# is not in the form data because the settings page was out of date with the current list of authors, don't add the author to the user's story_never_author list.
