### PR TITLE
Fix for issue #328

### DIFF
--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -1634,6 +1634,7 @@ sub saveComment {
 		$karma_bonus = 1 if $pts >= 1 && $user->{karma} > $constants->{goodkarma}
 			&& !$comm->{nobonus};
 		$subscriber_bonus = 1 if $constants->{plugin}{Subscribe}
+			&& $constants->{subscriber_bonus}
 			&& $user->{is_subscriber}
 			&& (!$comm->{nosubscriberbonus} || $comm->{nosubscriberbonus} ne 'on');
 	}
@@ -1893,7 +1894,7 @@ sub dispComment {
 	}
 	
 	my $subscriber_bonus;
-	if ($constants->{plugin}{Subscribe} && $constants->{subscribe}) {
+	if ($constants->{plugin}{Subscribe} && $constants->{subscribe} && $constants->{subscriber_bonus}) {
 		my $hide_subscription = $reader->getUser($comment->{uid}, 'hide_subscription');
 		if (isSubscriber($comment->{uid}) && !$hide_subscription) {
 			$subscriber_bonus = 'yes';

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -372,3 +372,6 @@ INSERT INTO vars (name, value, description) VALUES ('signoffs_per_article','2','
 
 # Fix Subs Messages
 UPDATE message_codes SET delivery_bvalue=1 WHERE type LIKE 'Subscription%';
+
+# Unset subscriber_bonus on comments since it got set due to a bug.
+update comments set subscriber_bonus = 'no' where subscriber_bonus = 'yes';


### PR DESCRIPTION
subscriber_bonus was getting set on comments even when subscriber_bonus in vars was set to zero. this caused comment scores to display incorrectly on the user info page.
