### PR TITLE
BadPasswordLog saved cleartext bad passwords.

### DIFF
--- a/Slash/DB/MySQL/MySQL.pm
+++ b/Slash/DB/MySQL/MySQL.pm
@@ -1680,7 +1680,7 @@ sub getUserAuthenticate {
 	# If we tried to authenticate and failed, log this attempt to
 	# the badpasswords table.
 	if (!$uid_verified) {
-		$self->createBadPasswordLog($uid_try, $passwd);
+		$self->createBadPasswordLog($uid_try, "");
 	}
 
 	# return UID alone in scalar context
@@ -1691,6 +1691,7 @@ sub getUserAuthenticate {
 # Log a bad password in a login attempt.
 sub createBadPasswordLog {
 	my($self, $uid, $password_wrong) = @_;
+	$password_wrong = "";
 	my $constants = getCurrentStatic();
 
 	# Failed login attempts as the anonymous coward don't count.


### PR DESCRIPTION
This is a security hole as sysadmins could view users failed passwords and guess at their real passwords and use it to potentially log into other services.  This bug was mitigated by the fact that the badpassowrd table gets purged and only holds a couple of days worth of bad password.  This will be accompanied by setting the password field on the badpassword table to “”.
