### PR TITLE
Temporary, incomplete fix for superfluous RSS/Atom encoding

### DIFF
--- a/Slash/XML/RSS/RSS.pm
+++ b/Slash/XML/RSS/RSS.pm
@@ -325,6 +325,8 @@ sub create {
 					my $data = $item->{$key};
 					if ($key eq 'link') {
 						$data = _tag_link($data);
+						$encoded_item->{$key} = $data;
+						next;
 					}
 					$encoded_item->{$key} = $self->encode($data, $key);
 				}
@@ -392,8 +394,9 @@ sub rss_story {
 	my $other_creator;
 	my $action;
 
+	$encoded_item->{title} = $story->{title};
 	$encoded_item->{title}  = $self->encode($story->{title})
-		if $story->{title};
+		if $story->{title} && $atom;
 	if ($story->{sid}) {
 		my $edit = "admin.pl?op=edit&sid=$story->{sid}";
 		my $linktitle = $story->{title};

--- a/themes/default/tasks/open_backend.pl
+++ b/themes/default/tasks/open_backend.pl
@@ -110,6 +110,15 @@ sub _do_rss {
 		} if $newurl;
 	}
 
+	# Undo all encoding and let xmlDisplay handle that
+	foreach my $item (@items) {
+		foreach("title","introtext","bodytext"."link"){
+			$item->{story}{$_} =~ s/\&#(\d+);/chr($1)/ge;
+			$item->{story}{$_} =~ s/\&#x([a-fA-F0-9]+);/chr(hex($1))/ge;
+			$item->{story}{$_} =~ s/\&amp;/&/g;
+		}
+	}
+
 	my $rss = xmlDisplay($type, {
 		channel		=> {
 			title		=> $title,
@@ -125,11 +134,11 @@ sub _do_rss {
 
 	save2file("$constants->{basedir}/$filename", $rss, \&fudge);
 
-    # Now write change the links to https, add an s to the front of the extension, and write it again
+	# Now write change the links to https, add an s to the front of the extension, and write it again
 
-    $filename =~ s/\./.s/;
-    $rss =~ s/http:/https:/g;
-    save2file("$constants->{basedir}/$filename", $rss, \&fudge);
+	$filename =~ s/\./.s/;
+	$rss =~ s/http:/https:/g;
+	save2file("$constants->{basedir}/$filename", $rss, \&fudge);
 }
 
 sub newrdf  { _do_rss(@_, '0.9') } # RSS 0.9


### PR DESCRIPTION
This is the best I can do for now. We really need to stop encoding story data before they go into the DB and only encode them on display like we do for comments. We also very much need to rewrite huge swaths of feed generation as how we do it now is a convoluted mess even for slash.
