### PR TITLE
convert entity diacritics to literal ones

### DIFF
--- a/Slash/Constants/Constants.pm
+++ b/Slash/Constants/Constants.pm
@@ -171,10 +171,11 @@ change Slash::Data::strip_mode() to allow the new value.
 	EXTRANS
 	CODE
 	FULLHTML
+	TEXTAREA
 
 =cut
 
-# -4 -3 -2 -1 0 1 2 3 4 77
+# -4 -3 -2 -1 0 1 2 3 4 77 78
 
 =head2 people
 

--- a/Slash/Display/Display.pm
+++ b/Slash/Display/Display.pm
@@ -363,6 +363,7 @@ my $strip_mode = sub {
 	strip_nohtml		=> \&strip_nohtml,
 	strip_notags		=> \&strip_notags,
 	strip_plaintext		=> \&strip_plaintext,
+	strip_textarea		=> \&strip_textarea,
 	strip_mode		=> [ $strip_mode, 1 ],
 	%FILTERS
 );

--- a/Slash/Utility/Data/Data.pm
+++ b/Slash/Utility/Data/Data.pm
@@ -124,6 +124,7 @@ our @EXPORT  = qw(
 	strip_attribute
 	strip_code
 	strip_extrans
+	strip_textarea
 	strip_html
 	strip_literal
 	strip_mode
@@ -1341,6 +1342,8 @@ my %actions = (
 			${$_[0]} =~ s/&/&amp;/g;			},
 	encode_html_amp_ifnotent => sub {
 			${$_[0]} =~ s/&(?!#?[a-zA-Z0-9]+;)/&amp;/g;	},
+	encode_html_amp_ifent => sub {
+			${$_[0]} =~ s/&(#?[a-zA-Z0-9]+;)/&amp;$1/g;	},
 	encode_html_ltgt => sub {
 			${$_[0]} =~ s/</&lt;/g;
 			${$_[0]} =~ s/>/&gt;/g;				},
@@ -1505,6 +1508,12 @@ my %mode_actions = (
 			whitespace_tagify
 			newline_indent
 			approve_unicode		)],
+	TEXTAREA, [qw(
+			newline_to_local
+			encode_html_amp_ifent
+			encode_html_ltgt	)],
+
+	
 );
 
 sub stripByMode {
@@ -1573,6 +1582,7 @@ sub strip_literal	{ stripByMode($_[0], LITERAL,	@_[1 .. $#_]) }
 sub strip_nohtml	{ stripByMode($_[0], NOHTML,	@_[1 .. $#_]) }
 sub strip_notags	{ stripByMode($_[0], NOTAGS,	@_[1 .. $#_]) }
 sub strip_plaintext	{ stripByMode($_[0], PLAINTEXT,	@_[1 .. $#_]) }
+sub strip_textarea	{ stripByMode($_[0], TEXTAREA,	@_[1 .. $#_]) }
 
 sub determine_html_format {
 	my($html, $user) = @_;

--- a/themes/default/templates/edit_comment;comments;default
+++ b/themes/default/templates/edit_comment;comments;default
@@ -133,7 +133,7 @@ END %]
 [% END %]
 
 	[% PROCESS formLabel value => 'Subject' %]
-		<input type="text" name="postersubj" value="[% form.postersubj %]" size="50" maxlength="50">
+		<input type="text" name="postersubj" value="[% form.postersubj | strip_attribute %]" size="50" maxlength="50">
 	[% FOR extra = extras %]
 	
 		<b>[% extra.0 %]
@@ -148,7 +148,7 @@ END %]
 	[% END %]
 	
 		[% PROCESS formLabel value => 'Comment' %]
-		<textarea class="fullbox" wrap="virtual" name="postercomment" id="postercomment" rows="[% user.textarea_rows || constants.textarea_rows %]" cols="[% user.textarea_cols || constants.textarea_cols %]">[% form.postercomment %]</textarea>
+		<textarea class="fullbox" wrap="virtual" name="postercomment" id="postercomment" rows="[% user.textarea_rows || constants.textarea_rows %]" cols="[% user.textarea_cols || constants.textarea_cols %]">[% form.postercomment | strip_textarea %]</textarea>
 		[% PROCESS formNote note => 'Use the Preview Button! Check those URLs!' %]
 		<br>
 		[% IF user.is_anon %]


### PR DESCRIPTION
This needs to be done to prevent alternating entities and literals from being chained to bypass our limit on them. Also removed strip_literal from the text input fields on comment previews. There's no point in it as they can edit that to make it say whatever they want anyway. I'll likely be doing the same to journals and subs soon as well.
