### PR TITLE
Switch feeds to https.

### DIFF
--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -437,3 +437,6 @@ INSERT INTO vars (name, value, description) VALUES ('approvedtags_visible', 'b|i
 # Add <user>nick</user> linking
 UPDATE vars SET value = 'b|i|p|br|a|ol|ul|li|dl|dt|dd|em|strong|tt|blockquote|div|ecode|quote|sup|sub|strike|abbr|sarc|sarcasm|user' WHERE name = 'approvedtags';
 UPDATE vars SET value = 'b|i|p|br|a|ol|ul|li|dl|dt|dd|em|strong|tt|blockquote|div|ecode|quote|strike|sarc|sarcasm|user' WHERE name = 'approvedtags_visible';
+
+# This switches feeds to https. http was hardcoded if you don't assign a url to a skin.
+UPDATE skins SET url = 'https://soylentnews.org/' where name = 'mainpage';


### PR DESCRIPTION
Switches main feeds to use https links. They're hardcoded to use http unless url is set for the nexus's skin.  Old https alternate feeds code still needs to be removed but it would conflict with stuff edited in another pull request.
