### PR TITLE
Modwork

### DIFF
--- a/Slash/DB/MySQL/MySQL.pm
+++ b/Slash/DB/MySQL/MySQL.pm
@@ -9123,6 +9123,7 @@ sub getDiscussionParent {
 		$parent->{type} = 'poll';
 	}
 	else{return undef};
+	$parent->{content} = parseSlashizedLinks($parent->{content});
 	return $parent;
 }
 

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -275,9 +275,10 @@ sub selectComments {
 		$comments->{$C->{pid}}{visiblekids}++
 			if $C->{points} >= (defined $threshold ? $threshold : $min);
 
+		# This fucking shit belongs in _can_mod, goddamnit
 		# Can't mod in a discussion that you've posted in.
 		# Just a point rule -Brian
-		$user->{points} = 0 if $C->{uid} == $user->{uid}; # Mod/Post Rule
+		#$user->{points} = 0 if $C->{uid} == $user->{uid}; # Mod/Post Rule
 	}
 ##slashProf("sC more fudging", "sC fudging");
 
@@ -924,7 +925,6 @@ sub _can_mod {
 	my($comment) = @_;
 	my $user = getCurrentUser();
 	my $constants = getCurrentStatic();
-
 	# Do some easy and high-priority initial tests.  If any of
 	# these is true, this comment is not moderatable, and these
 	# override the ACL and seclev tests.
@@ -947,12 +947,15 @@ sub _can_mod {
 	# OK, the user is an ordinary user, so see if they have mod
 	# points and do some other fairly ordinary tests to try to
 	# rule out whether they can mod.
+	# No modding your own comments
+	if(defined($user->{uid}) && defined($comment->{uid})) {
+		return 0 if $user->{uid} eq $comment->{uid};
+	}
 	return 0 if
 		    $user->{points} <= 0
 		|| !$user->{willing}
-		||  $comment->{uid} == $user->{uid}
-		||  $comment->{lastmod} == $user->{uid}
-		||  $comment->{ipid} eq $user->{ipid};
+		||  $comment->{ipid} eq $user->{ipid}
+	;
 	return 0 if
 		    $constants->{mod_same_subnet_forbid}
 		&&  $comment->{subnetid} eq $user->{subnetid};

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -2662,9 +2662,9 @@ sub discussion2 {
 
 sub _is_mod_banned {
 	my $user = shift;
-	my $slashdb = getCurrentDB();
+	my $reader = getObject('Slash::DB', { db_type => 'reader' });
 
-	my $banned = $slashdb->sqlSelect("1", 'users_info', "uid = $user->{uid} and mod_banned > NOW()");
+	my $banned = $reader->sqlSelect("1", 'users_info', "uid = $user->{uid} and mod_banned > NOW()");
 	return ($banned || 0);
 }
 

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -929,10 +929,11 @@ sub _can_mod {
 	# these is true, this comment is not moderatable, and these
 	# override the ACL and seclev tests.
 	return 0 if !$comment;
-	return 0 if
+	return 0 and print STDERR "\nWTF\n" if
 		    $user->{is_anon}
 		|| !$constants->{m1}
-		||  $comment->{no_moderation};
+		||  $comment->{no_moderation}
+		||  _is_mod_banned($user);
 	
 	# More easy tests.  If any of these is true, the user has
 	# authorization to mod any comments, regardless of any of
@@ -2657,6 +2658,14 @@ sub discussion2 {
 #	return $user->{discussion2} eq 'slashdot'
 #		? $user->{discussion2} : 0;
 	return 0;
+}
+
+sub _is_mod_banned {
+	my $user = shift;
+	my $slashdb = getCurrentDB();
+
+	my $banned = $slashdb->sqlSelect("1", 'users_info', "uid = $user->{uid} and mod_banned > NOW()");
+	return ($banned || 0);
 }
 
 

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -929,7 +929,7 @@ sub _can_mod {
 	# these is true, this comment is not moderatable, and these
 	# override the ACL and seclev tests.
 	return 0 if !$comment;
-	return 0 and print STDERR "\nWTF\n" if
+	return 0 if
 		    $user->{is_anon}
 		|| !$constants->{m1}
 		||  $comment->{no_moderation}

--- a/Slash/Utility/Comments/Comments.pm
+++ b/Slash/Utility/Comments/Comments.pm
@@ -1971,8 +1971,11 @@ EOT
 		return @return;
 	}
 
+	my $marked_spam = $mod_reader->getSpamCount($comment->{cid}, $reasons);
+
 	return slashDisplay('dispComment', {
 		%$comment,
+		marked_spam	=> $marked_spam,
 		comment_shrunk	=> $comment_shrunk,
 		reasons		=> $reasons,
 		can_mod		=> $can_mod,

--- a/plugins/Moderation/Moderation.pm
+++ b/plugins/Moderation/Moderation.pm
@@ -1314,6 +1314,97 @@ sub getSpamCount {
 	return "";
 }
 
+# Ban $uid from moderating for 
+sub modBanUID {
+	my ($self, $uid) = @_;
+	my $constants = getCurrentStatic();
+	use DateTime;
+	use DateTime::Format::MySQL;
+	my $dtToday = DateTime->today;
+	my $dtBan;
+
+	my $currentBan = $self->sqlSelect('mod_banned', 'users_info', "uid = $uid");
+
+	# Decide the ban length
+	if($currentBan) {
+		$dtBan = DateTime::Format::MySQL->parse_date($currentBan);
+		if($dtBan > $dtToday){return 1;} # already serving a ban, nothing to do
+		$dtBan = DateTime->today;
+		$dtBan->add( days => $constants->{m1_ban_duration} );
+	}
+	else {
+		$dtBan = $dtToday;
+		$dtBan->add( days => $constants->{m1_1st_ban_duration} );
+	}
+	
+	# Now set the ban.
+	my $banUntil = DateTime::Format::MySQL->format_date($dtBan);
+	return $self->setUser( $uid, { mod_banned => $banUntil } );
+}
+
+sub undoSingleModeration {
+	my ($self, $mod) = @_;
+	# $mod is a hash of a single line of the moderatorlog table
+	
+	$self->undoSingleModKarma($mod) or print STDERR "\nFailed to restore karma to $mod->{cuid}\n" and return 0;
+	$self->recalcCommentScore($mod->{cid}) or print STDERR "\nFailed to recalculate comment score for $mod->{cid}\n" and return 0;
+	return 1;
+}
+
+sub recalcCommentScore {
+	my ($self, $cid) = @_;
+	my $constants = getCurrentStatic();
+	
+	my $scores = $self->sqlSelectAll("val", "moderatorlog", "cid = $cid");
+	my $points = 0;
+	if($scores) {
+		my $minScore = $constants->{comment_minscore};
+		my $maxScore = $constants->{comment_maxscore};
+		foreach my $score (@$scores) {
+			$points += $score;
+		}
+		$points = $minScore if $points < $minScore;
+		$points = $maxScore if $points > $maxScore;
+	}
+	# stopped here
+	$self->sqlUpdate("comments", { points => $points }, "cid = $cid") or return 0;
+	
+	my $newReason = $self->getCommentMostCommonReason($cid)
+			|| 0; # no active moderations? reset reason to empty
+
+	$self->sqlUpdate("comments", { reason => $newReason }, "cid=$cid") or return 0;
+	return 1;
+}
+
+sub undoSingleModKarma {
+	my ($self, $mod) = @_;
+	# $mod is a hash of a single line of the moderatorlog table
+	my $constants = getCurrentStatic();
+	my $cuid = $mod->{cuid}; # who was modded
+	my $user = $self->getUser($cuid);
+	my $minKarma = $constants->{minkarma};
+	my $maxKarma = $constants->{maxkarma};
+	my $karmaHit = $self->sqlSelect('karma', 'modreasons', " id = $mod->{reason} ");
+
+	# Nothing to do if there is no karma hit or the person modded was AC
+	if( ($karmaHit == 0) || isAnon($cuid) ) {return 1;}
+	elsif($karmaHit < 0) {
+		return 1 if $user->{karma} eq $maxKarma;
+		my $newKarma = $user->{karma} + abs($karmaHit);
+		if($newKarma >= $maxKarma){$self->setUser($cuid, { karma => $maxKarma } ) or return 0;}
+		else{$self->setUser($cuid, { karma => $newKarma } ) or return 0;}
+		return 1;
+	}
+	elsif($karmaHit > 0) {
+		return 1 if $user->{karma} eq $minKarma;
+		my $newKarma = $user->{karma} - abs($karmaHit);
+		if($newKarma <= $minKarma){$self->setUser($cuid, { karma => $minKarma } ) or return 0;}
+		else{$self->setUser($cuid, { karma => $newKarma } ) or return 0;}
+		return 1;
+	}
+	else {print STDERR "\nHow the fuck did we even get here?\n"; return 0;}
+}
+
 # placeholders, used only in TagModeration
 sub removeModTags {}
 sub createModTag  {}

--- a/plugins/Moderation/Moderation.pm
+++ b/plugins/Moderation/Moderation.pm
@@ -139,6 +139,11 @@ sub moderateComment {
 
 	my $comment = $options->{comment} || $self->getComment($cid);
 
+	# No moderating of your own comments.
+	if ($comment->{uid} eq $user->{uid} && !$superAuthor) {
+		return -3;
+	}
+
 	# Start putting together the data we'll need to display to
 	# the user.
 	my $reasons = $self->getReasons();
@@ -878,6 +883,9 @@ sub moderateCheck {
 	}
 
 	my $return = {};
+	# short circuit for mod-and-post being allowed
+	return $return if $constants->{moderate_or_post} eq 2;
+
 	$return->{count} = $self->countCommentsBySidUID($form->{sid}, $user->{uid})
 		unless (   $constants->{authors_unlimited}
 			&& $user->{seclev} >= $constants->{authors_unlimited}

--- a/plugins/Moderation/Moderation.pm
+++ b/plugins/Moderation/Moderation.pm
@@ -546,7 +546,9 @@ sub getCommentMostCommonReason {
 		my $new_hr = { };
 		for my $reason (keys %$hr) {
 			$new_hr->{$reason} = $hr->{$reason}
-				if $reasons->{$hr->{$reason}{reason}}{val} == $needval;
+				# What say we just give the actual most common reason?
+				#if $reasons->{$hr->{$reason}{reason}}{val} == $needval;
+				;
 		}
 		$hr = $new_hr;
 	}

--- a/plugins/Moderation/Moderation.pm
+++ b/plugins/Moderation/Moderation.pm
@@ -1293,6 +1293,27 @@ sub stirPool {
 	return $n_stirred;
 } 
 
+sub getSpamCount {
+	my ($self, $cid, $reasons) = @_;
+	my $user = getCurrentUser();
+	if($cid !~ /^\d+$/) {
+		print STDERR "\nGot non-numeric cid '$cid' in getSpamLink\n";
+		return "";
+	}
+	my $spamreason;
+	foreach my $reason (values %$reasons) {
+		$spamreason = $reason->{id} if $reason->{name} eq 'Spam';
+	}
+	return "" unless $spamreason;
+
+	my $count = $self->sqlCount('moderatorlog',
+		"reason = $spamreason AND cid = $cid");
+	if( ($count) && ($user->{seclev} >= 100) ) {
+		return $count;
+	}
+	return "";
+}
+
 # placeholders, used only in TagModeration
 sub removeModTags {}
 sub createModTag  {}

--- a/plugins/Moderation/Moderation.pm
+++ b/plugins/Moderation/Moderation.pm
@@ -1325,7 +1325,7 @@ sub modBanUID {
 	my $dtToday = DateTime->today;
 	my $dtBan;
 
-	my $currentBan = $self->sqlSelect('mod_banned', 'users_info', "uid = $uid");
+	my $currentBan = $self->sqlSelect('mod_banned', 'users_info', "uid = $uid AND mod_banned <> '1000-01-01'");
 
 	# Decide the ban length
 	if($currentBan) {

--- a/plugins/Moderation/Moderation.pm
+++ b/plugins/Moderation/Moderation.pm
@@ -325,8 +325,9 @@ sub setCommentForMod {
 	my($self, $cid, $val, $newreason, $oldreason) = @_;
 	my $raw_val = $val;
 	$val += 0;
-	return undef if !$val;
-	$val = "+$val" if $val > 0;
+	# Need to allow for +0 moderations
+	return undef if !defined($val);
+	$val = "+$val" if $val >= 0;
 
 	my $user = getCurrentUser();
 	my $constants = getCurrentStatic();
@@ -541,6 +542,7 @@ sub getCommentMostCommonReason {
 	if ($needval) {
 		   if ($needval >  1) { $needval =  1 }
 		elsif ($needval < -1) { $needval = -1 }
+		else { $needval = 0; }
 		my $new_hr = { };
 		for my $reason (keys %$hr) {
 			$new_hr->{$reason} = $hr->{$reason}

--- a/plugins/Moderation/process_moderation.pl
+++ b/plugins/Moderation/process_moderation.pl
@@ -12,7 +12,8 @@ use Slash::Constants qw( :messages :slashd );
 
 use vars qw( %task $me $task_exit_flag );
 
-$task{$me}{timespec} = '*/5 0-23 * * *';
+#$task{$me}{timespec} = '*/5 0-23 * * *';
+$task{$me}{timespec} = '10 0 * * *';
 $task{$me}{timespec_panic_1} = '';
 $task{$me}{resource_locks} = { log_slave => 1, moderatorlog => 1 };
 $task{$me}{fork} = SLASHD_NOWAIT;
@@ -31,14 +32,22 @@ $task{$me}{code} = sub {
 	# 2. Work out if we need to issue more points to get the system
 	#    balanaced if we have points
 	# 3. Work out who to give points to, and issue
-	my $points_to_handout;
+	#my $points_to_handout;
 	
-	stir_mod_pool();
+	#stir_mod_pool();
 	
 	# Note, points to hand out CAN be negative, in that case, the system
 	# only hands out minimium points (as always more modpoints is better)
-	$points_to_handout = determine_mod_points_to_be_issued($slashdb);
-	distributeModPoints($constants, $slashdb, $points_to_handout);
+	#$points_to_handout = determine_mod_points_to_be_issued($slashdb);
+	#distributeModPoints($constants, $slashdb, $points_to_handout);
+
+	# New method for the experiment
+	use DateTime;
+	use DateTime::Format::MySQL;
+	my $dtNow = DateTime->now;
+	my $now = DateTime::Format::MySQL->format_date($dtNow);
+	my $acUID = $constants->{anonymous_coward_uid};
+	$slashdb->sqlUpdate("users_info", { points => 5,  lastgranted => $now }, "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID");
 	
 	return ;
 };

--- a/plugins/Moderation/process_moderation.pl
+++ b/plugins/Moderation/process_moderation.pl
@@ -47,10 +47,8 @@ $task{$me}{code} = sub {
 	my $dtNow = DateTime->now;
 	my $now = DateTime::Format::MySQL->format_date($dtNow);
 	my $acUID = $constants->{anonymous_coward_uid};
-	my $where = "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID";
+	my $where = "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID AND mod_banned < NOW()";
 	$slashdb->sqlUpdate("users_info", { points => 5,  lastgranted => $now }, $where);
-	# My SQL-fu is not good enough to not give them points in the first place, so...
-	$slashdb->sqlUpdate("users_info", { points => 0 }, "mod_banned > NOW()");
 	
 	return ;
 };

--- a/plugins/Moderation/process_moderation.pl
+++ b/plugins/Moderation/process_moderation.pl
@@ -49,7 +49,7 @@ $task{$me}{code} = sub {
 	my $acUID = $constants->{anonymous_coward_uid};
 	my $points = $constants->{m1_pointsgrant_arbitrary};
 	my $rows = $slashdb->sqlDo(
-		"update users_info join users_prefs on users_info.uid = users_prefs.uid  set points = $points where created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND users_info.uid <> $acUID AND mod_banned < NOW() AND willing = 1;");
+		"update users_info join users_prefs on users_info.uid = users_prefs.uid  set points = $points, lastgranted = NOW() where created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND users_info.uid <> $acUID AND mod_banned < NOW() AND willing = 1;");
 	#my $where = "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID AND mod_banned < NOW()";
 	#$slashdb->sqlUpdate("users_info", { points => $constants->{m1_pointsgrant_arbitrary},  lastgranted => $now }, $where);
 	

--- a/plugins/Moderation/process_moderation.pl
+++ b/plugins/Moderation/process_moderation.pl
@@ -47,7 +47,10 @@ $task{$me}{code} = sub {
 	my $dtNow = DateTime->now;
 	my $now = DateTime::Format::MySQL->format_date($dtNow);
 	my $acUID = $constants->{anonymous_coward_uid};
-	$slashdb->sqlUpdate("users_info", { points => 5,  lastgranted => $now }, "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID");
+	my $where = "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID";
+	$slashdb->sqlUpdate("users_info", { points => 5,  lastgranted => $now }, $where);
+	# My SQL-fu is not good enough to not give them points in the first place, so...
+	$slashdb->sqlUpdate("users_info", { points => 0 }, "mod_banned > NOW()");
 	
 	return ;
 };

--- a/plugins/Moderation/process_moderation.pl
+++ b/plugins/Moderation/process_moderation.pl
@@ -42,13 +42,16 @@ $task{$me}{code} = sub {
 	#distributeModPoints($constants, $slashdb, $points_to_handout);
 
 	# New method for the experiment
-	use DateTime;
-	use DateTime::Format::MySQL;
-	my $dtNow = DateTime->now;
-	my $now = DateTime::Format::MySQL->format_date($dtNow);
+	#use DateTime;
+	#use DateTime::Format::MySQL;
+	#my $dtNow = DateTime->now;
+	#my $now = DateTime::Format::MySQL->format_date($dtNow);
 	my $acUID = $constants->{anonymous_coward_uid};
-	my $where = "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID AND mod_banned < NOW()";
-	$slashdb->sqlUpdate("users_info", { points => 5,  lastgranted => $now }, $where);
+	my $points = $constants->{m1_pointsgrant_arbitrary};
+	my $rows = $slashdb->sqlDo(
+		"update users_info join users_prefs on users_info.uid = users_prefs.uid  set points = $points where created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND users_info.uid <> $acUID AND mod_banned < NOW() AND willing = 1;");
+	#my $where = "created_at < DATE_SUB(NOW(), INTERVAL 1 MONTH) AND uid <> $acUID AND mod_banned < NOW()";
+	#$slashdb->sqlUpdate("users_info", { points => $constants->{m1_pointsgrant_arbitrary},  lastgranted => $now }, $where);
 	
 	return ;
 };

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -456,3 +456,4 @@ ALTER TABLE users_info ADD mod_banned date DEFAULT '1000-01-01';
 INSERT INTO vars (name, value, description) VALUES ('m1_1st_ban_duration', '30', 'Duration of ban in days the first time someone is banned from moderating');
 INSERT INTO vars (name, value, description) VALUES ('m1_ban_duration', '180', 'Duration of ban in days all subsequent times someone is banned from moderating');
 INSERT INTO vars (name, value, description) VALUES ('m1_pointsgrant_arbitrary', '5', 'Number of points to grant when we are arbitrarily granting mod points.');
+INSERT INTO vars (name, value, description) VALUES ('moderate_or_post', '2', '0 = or, 1 = then, 2 = and');

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -450,3 +450,4 @@ INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES
 INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (12, 'Disagree', 0, 1, 0, 0, 0.5);
 DELETE FROM modreasons WHERE id = 9;
 DELETE FROM modreasons WHERE id = 10;
+ALTER TABLE users_info ADD mod_banned datetime DEFAULT NULL;

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -440,3 +440,13 @@ UPDATE vars SET value = 'b|i|p|br|a|ol|ul|li|dl|dt|dd|em|strong|tt|blockquote|di
 
 # This switches feeds to https. http was hardcoded if you don't assign a url to a skin.
 UPDATE skins SET url = 'https://soylentnews.org/' where name = 'mainpage';
+
+# For the moderation rework
+UPDATE modreasons SET val = 0, karma = 0 WHERE id = 1;
+UPDATE modreasons SET val = 0, karma = 0 WHERE id = 2;
+UPDATE modreasons SET val = 0, karma = 0 WHERE id = 3;
+UPDATE modreasons SET val = 0, karma = 0 WHERE id = 4;
+INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (11, 'Spam', 0, 1, -1, -10, 0.5);
+INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (12, 'Disagree', 0, 1, 0, 0, 0.5);
+DELETE FROM modreasons WHERE id = 9;
+DELETE FROM modreasons WHERE id = 10;

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -450,4 +450,6 @@ INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES
 INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (12, 'Disagree', 0, 1, 0, 0, 0.5);
 DELETE FROM modreasons WHERE id = 9;
 DELETE FROM modreasons WHERE id = 10;
-ALTER TABLE users_info ADD mod_banned datetime DEFAULT NULL;
+ALTER TABLE users_info ADD mod_banned date DEFAULT NULL;
+INSERT INTO vars (name, value, description) VALUES ('m1_1st_ban_duration', '30', 'Duration of ban in days the first time someone is banned from moderating');
+INSERT INTO vars (name, value, description) VALUES ('m1_ban_duration', '180', 'Duration of ban in days all subsequent times someone is banned from moderating');

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -442,14 +442,17 @@ UPDATE vars SET value = 'b|i|p|br|a|ol|ul|li|dl|dt|dd|em|strong|tt|blockquote|di
 UPDATE skins SET url = 'https://soylentnews.org/' where name = 'mainpage';
 
 # For the moderation rework
-UPDATE modreasons SET val = 0, karma = 0 WHERE id = 1;
-UPDATE modreasons SET val = 0, karma = 0 WHERE id = 2;
-UPDATE modreasons SET val = 0, karma = 0 WHERE id = 3;
-UPDATE modreasons SET val = 0, karma = 0 WHERE id = 4;
+# Commented lines are held back but may go in at a later date
+#UPDATE modreasons SET val = 0, karma = 0 WHERE id = 1;
+#UPDATE modreasons SET val = 0, karma = 0 WHERE id = 2;
+#UPDATE modreasons SET val = 0, karma = 0 WHERE id = 3;
+#UPDATE modreasons SET val = 0, karma = 0 WHERE id = 4;
 INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (11, 'Spam', 0, 1, -1, -10, 0.5);
 INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (12, 'Disagree', 0, 1, 0, 0, 0.5);
+INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (13, 'Touche', 0, 1, 1, 1, 0.5);
 DELETE FROM modreasons WHERE id = 9;
-DELETE FROM modreasons WHERE id = 10;
+#DELETE FROM modreasons WHERE id = 10;
 ALTER TABLE users_info ADD mod_banned date DEFAULT '1000-01-01';
 INSERT INTO vars (name, value, description) VALUES ('m1_1st_ban_duration', '30', 'Duration of ban in days the first time someone is banned from moderating');
 INSERT INTO vars (name, value, description) VALUES ('m1_ban_duration', '180', 'Duration of ban in days all subsequent times someone is banned from moderating');
+INSERT INTO vars (name, value, description) VALUES ('m1_pointsgrant_arbitrary', '5', 'Number of points to grant when we are arbitrarily granting mod points.');

--- a/sql/mysql/upgrades
+++ b/sql/mysql/upgrades
@@ -450,6 +450,6 @@ INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES
 INSERT INTO modreasons (id, name, m2able, listable, val, karma, fairfrac) VALUES (12, 'Disagree', 0, 1, 0, 0, 0.5);
 DELETE FROM modreasons WHERE id = 9;
 DELETE FROM modreasons WHERE id = 10;
-ALTER TABLE users_info ADD mod_banned date DEFAULT NULL;
+ALTER TABLE users_info ADD mod_banned date DEFAULT '1000-01-01';
 INSERT INTO vars (name, value, description) VALUES ('m1_1st_ban_duration', '30', 'Duration of ban in days the first time someone is banned from moderating');
 INSERT INTO vars (name, value, description) VALUES ('m1_ban_duration', '180', 'Duration of ban in days all subsequent times someone is banned from moderating');

--- a/themes/default/htdocs/comments.pl
+++ b/themes/default/htdocs/comments.pl
@@ -200,7 +200,7 @@ sub main {
 	my $header_emitted = 0;
 	my $title = $constants->{sitename} . '  Comments';
 	$title .= " | $discussion->{'title'}" if $discussion;
-	if ($op ne 'submit') {
+	if ($op ne 'submit' && $op ne 'unspam') {
 		header($title, $section) or return;
 		$header_emitted = 1;
 	}
@@ -829,19 +829,19 @@ sub deleteThread {
 
 sub unspamComment {
 	my ($form, $slashdb, $user, $constants, $discussion) = @_;
-	use Data::Dumper;
+	my $rootdir = getCurrentSkin("rootdir");
 	my $moddb = getObject("Slash::$constants->{m1_pluginname}");
 
 	if(!$moddb) {
 		print STDERR "\nERROR: Could not get moddb.\n";
-		displayComments($form, $slashdb, $user, $constants, $discussion);
+		redirect("$rootdir/comments.pl?sid=$form->{sid}#$form->{cid}", 301);
 		return;
 	}
 	
 	my $cid = $form->{cid};
 	if($cid !~ /^\d+$/) {
 		print STDERR "\nGot non-numeric cid '$cid' in \$form. Bailing to simple display.\n";
-		displayComments($form, $slashdb, $user, $constants, $discussion);
+		redirect("$rootdir/comments.pl?sid=$form->{sid}#$form->{cid}", 301);
 		return;
 	}
 
@@ -850,7 +850,7 @@ sub unspamComment {
 					"name = 'Spam'");
 	if(!$spamreason) {
 		print STDERR "\nGot undef for \$spamreason. WTF?\n";
-		displayComments($form, $slashdb, $user, $constants, $discussion);
+		redirect("$rootdir/comments.pl?sid=$form->{sid}#$form->{cid}", 301);
 		return;
 	}
 	
@@ -872,7 +872,7 @@ sub unspamComment {
 		my ($modderUID, $commenterUID, $modLogID) = ($spamMod->{uid}, $spamMod->{cuid}, $spamMod->{id});
 		# Bail if we somehow got a bad entry without the proper data
 		unless ($modderUID && $commenterUID && $modLogID) {
-			displayComments($form, $slashdb, $user, $constants, $discussion);
+			redirect("$rootdir/comments.pl?sid=$form->{sid}#$form->{cid}", 301);
 			return;
 		}
 
@@ -893,7 +893,7 @@ sub unspamComment {
 	}
 
 	# Now redirect them back where they were.
-	displayComments($form, $slashdb, $user, $constants, $discussion);
+	redirect("$rootdir/comments.pl?sid=$form->{sid}#$form->{cid}", 301);
 	return;
 }
 

--- a/themes/default/htdocs/comments.pl
+++ b/themes/default/htdocs/comments.pl
@@ -885,11 +885,14 @@ sub unspamComment {
 		$moddb->undoSingleModeration($spamMod);
 
 		# Remove any mod points from the user who modded it spam
-		$slashdb->setUser( $user->{uid}, { points => 0 } );
+		$slashdb->setUser( $user->{uid}, { points => 0 } )
+			unless $form->{noban};
 
 		# Ban the user from moderating
-		my $banned = $moddb->modBanUID($modderUID);
-		print STDERR "\nGot a bad return value on modBanUID: uid=$modderUID" unless $banned;
+		unless($form->{noban}) {
+			my $banned = $moddb->modBanUID($modderUID);
+			print STDERR "\nGot a bad return value on modBanUID: uid=$modderUID" unless $banned;
+		}
 	}
 
 	# Now redirect them back where they were.

--- a/themes/default/htdocs/comments.pl
+++ b/themes/default/htdocs/comments.pl
@@ -718,6 +718,8 @@ sub moderate {
 					print Slash::Utility::Comments::getError('no points');
 				} elsif ($ret_val == -2){
 					print Slash::Utility::Comments::getError('not enough points');
+				} elsif ($ret_val == -3){
+					print Slash::Utility::Comments::getError('no self mods');
 				}
 			} else {
 				$was_touched += $ret_val;

--- a/themes/default/htdocs/users.pl
+++ b/themes/default/htdocs/users.pl
@@ -2171,7 +2171,7 @@ sub editComm {
 			push @reasons, $reasons->{$id}{name};
 		}
 		# Reason modifiers
-		for my $reason_name (@reasons) {
+		foreach my $reason_name (@reasons) {
 			my $key = "reason_alter_$reason_name";
 			$reason_select{$reason_name} = createSelect(
 				$key, \@range, 

--- a/themes/default/templates/dispComment;misc;default
+++ b/themes/default/templates/dispComment;misc;default
@@ -7,6 +7,7 @@ Display a comment
 * reasons = hashref of moderation "reasons" (or undef if no moderation plugin)
 * can_mod = boolean for whether or not current user can moderate
 * is_anon = boolean for whether or not comment user is anonymous
+* marked_spam = count of the times a comment has been moderated as spam, used as boolean
 
 Also included are all the individual elements of the comment and its
 poster: sid, cid, pid, date, subject, comment, uid, points, lastmod,
@@ -30,7 +31,9 @@ __template__
 	<div id="comment_top_[% cid %]" class="commentTop">
 		<div class="title">
 			<h4><a name="[% cid %]">[% subject %]</a>
-			[% UNLESS user.noscores %]<span id="comment_score_[% cid %]" class="score">([% IF constants.modal_prefs_active %]<a href="#" onclick="getModalPrefs('modcommentlog', 'Moderation Comment Log', [% cid %]); return false">[% END %]Score:[% points.length ? points : "?" %][% IF constants.modal_prefs_active %]</a>[% END %][% IF reasons && reason %], [% reasons.$reason.name %][% END %])</span>[% END %]</h4>
+				[% UNLESS user.noscores %]<span id="comment_score_[% cid %]" class="score">([% IF constants.modal_prefs_active %]<a href="#" onclick="getModalPrefs('modcommentlog', 'Moderation Comment Log', [% cid %]); return false">[% END %]Score:[% points.length ? points : "?" %][% IF constants.modal_prefs_active %]</a>[% END %][% IF reasons && reason %], [% reasons.$reason.name %][% END %])</span>[% END %]
+				[% IF marked_spam %] <a href="[% constants.real_rootdir %]/comments.pl?op=unspam&sid=[% sid %]&cid=[% cid %]">This is not Spam</a>[% END %]
+			</h4>
 		</div>
 		<div class="details">
 			by

--- a/themes/default/templates/dispComment;misc;default
+++ b/themes/default/templates/dispComment;misc;default
@@ -32,7 +32,7 @@ __template__
 		<div class="title">
 			<h4><a name="[% cid %]">[% subject %]</a>
 				[% UNLESS user.noscores %]<span id="comment_score_[% cid %]" class="score">([% IF constants.modal_prefs_active %]<a href="#" onclick="getModalPrefs('modcommentlog', 'Moderation Comment Log', [% cid %]); return false">[% END %]Score:[% points.length ? points : "?" %][% IF constants.modal_prefs_active %]</a>[% END %][% IF reasons && reason %], [% reasons.$reason.name %][% END %])</span>[% END %]
-				[% IF marked_spam %] <a href="[% constants.real_rootdir %]/comments.pl?op=unspam&sid=[% sid %]&cid=[% cid %]">This is not Spam</a>[% END %]
+				[% IF marked_spam %] <a href="[% constants.real_rootdir %]/comments.pl?op=unspam&sid=[% sid %]&cid=[% cid %]">Unspam and Ban</a> or <a href="[% constants.real_rootdir %]/comments.pl?op=unspam&sid=[% sid %]&cid=[% cid %]&noban=1">Unspam Only</a>[% END %]
 			</h4>
 		</div>
 		<div class="details">

--- a/themes/default/templates/dispLinkComment;misc;default
+++ b/themes/default/templates/dispLinkComment;misc;default
@@ -37,7 +37,7 @@ __template__
 			subject_only => 1,
 		}, 1) %]</b></p></span>[% END %]
 		
-		[% IF can_moderate %]
+		[% IF can_mod %]
 		<div id="reasondiv_[% cid %]" class="modsel">[% Slash.createSelect("reason_$cid", reasons, {
 			'return'	=> 1,
 			nsort		=> 1, 

--- a/themes/default/templates/editComm;users;default
+++ b/themes/default/templates/editComm;users;default
@@ -145,6 +145,9 @@ __template__
 				<td>	&nbsp; &nbsp; &nbsp;		</td>
 				<td>	Troll				</td>
 				<td>	[% reason_select.Troll %]	</td>
+				<td>	&nbsp; &nbsp; &nbsp;		</td>
+				<td>	Touche				</td>
+				<td>	[% reason_select.Touche %]	</td>
 			</tr>
 			<tr>
 				<td>	&nbsp; &nbsp; &nbsp;		</td>

--- a/themes/default/templates/editComm;users;default
+++ b/themes/default/templates/editComm;users;default
@@ -123,6 +123,9 @@ __template__
 				<td>	&nbsp; &nbsp; &nbsp;		</td>
 				<td>	Offtopic			</td>
 				<td>	[% reason_select.Offtopic %]	</td>
+				<td>	&nbsp; &nbsp; &nbsp;		</td>
+				<td>	Spam				</td>
+				<td>	[% reason_select.Spam %]	</td>
 			</tr>
 			<tr>
 				<td>	&nbsp; &nbsp; &nbsp;		</td>
@@ -131,6 +134,9 @@ __template__
 				<td>	&nbsp; &nbsp; &nbsp;		</td>
 				<td>	Flamebait			</td>
 				<td>	[% reason_select.Flamebait %]	</td>
+				<td>	&nbsp; &nbsp; &nbsp;		</td>
+				<td>	Disagree			</td>
+				<td>	[% reason_select.Disagree %]	</td>
 			</tr>
 			<tr>
 				<td>	&nbsp; &nbsp; &nbsp;		</td>

--- a/themes/default/templates/errors;comments;default
+++ b/themes/default/templates/errors;comments;default
@@ -75,6 +75,10 @@ You don't have any moderator points.
 CASE "not enough points" %]
 You don't have enough moderator points.
 
+[% # NO SELF MODS.
+CASE "no self mods" %]
+You can not moderate your own comments.
+
 [% # COMMENTS MAX POSTS.
 CASE "comments max posts" %]
 You've reached your maximum number of comments you can post: [% max_posts %] comments over [% timeframe %].


### PR DESCRIPTION
Allows moderate_or_post to be set to 2 and allow users to moderate and post in the same discussion. Also fixed a bug that was causing already moderated comments to still show moderation dropdown and button. Had to fix that to keep users from moderating their own comments.

Further, commented out some of the lines in upgrades that I'd prefer to roll out later after we've seen what the current changes will do to improve moderation.