### PR TITLE
Temporary fix for the tid bug

### DIFF
--- a/plugins/Admin/admin.pl
+++ b/plugins/Admin/admin.pl
@@ -1171,7 +1171,7 @@ sub editStory {
 			$storyref->{$field} = $slashdb->autoUrl($form->{section}, $storyref->{$field});
 			$storyref->{$field} = cleanSlashTags($storyref->{$field});
 			$storyref->{$field} = strip_html($storyref->{$field});
-			$storyref->{$field} = slashizeLinks($storyref->{$field});
+			#$storyref->{$field} = slashizeLinks($storyref->{$field});
 			$storyref->{$field} = parseSlashizedLinks($storyref->{$field});
 			$storyref->{$field} = balanceTags($storyref->{$field});
 		}
@@ -1794,7 +1794,7 @@ sub updateStory {
 		local $Slash::Utility::Data::approveTag::admin = 2;
 		$form->{$field} = cleanSlashTags($form->{$field});
 		$form->{$field} = strip_html($form->{$field});
-		$form->{$field} = slashizeLinks($form->{$field});
+		#$form->{$field} = slashizeLinks($form->{$field});
 		$form->{$field} = balanceTags($form->{$field});
 	}
 
@@ -2249,7 +2249,7 @@ sub saveStory {
 		local $Slash::Utility::Data::approveTag::admin = 2;
 		$form->{$field} = cleanSlashTags($form->{$field});
 		$form->{$field} = strip_html($form->{$field});
-		$form->{$field} = slashizeLinks($form->{$field});
+		#$form->{$field} = slashizeLinks($form->{$field});
 		$form->{$field} = balanceTags($form->{$field});
 	}
 


### PR DESCRIPTION
Stopping slashizing links in admin.pl for now so &tid=N isn't there to get messed up in the first place. The bug is in Data.pm in the sub _link_to_slashlink somewhere but I can't find it and don't have time to really dig in to it today.